### PR TITLE
Updated indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It's under development!
 ### Pinned plan
 
 - [ ] Kickall - Kick all players.
-- [ ] Exclude who entered the command
+  - [ ] Exclude who entered the command
 - [ ] Teleport
   - [ ] tp playername playername - Teleport from Player to Player
   - [x] tp playername - Teleport to Player.


### PR DESCRIPTION
The “exclude all players” wasn’t nested underneath the “kickall” command